### PR TITLE
Beta Patch + English Name

### DIFF
--- a/cloudSettings.json
+++ b/cloudSettings.json
@@ -2,7 +2,7 @@
   "keyword": "VRChat",
   "fetchIntervalMilliSeconds": 3000,
   "updateIntervalMilliSeconds": 1800000,
-  "modifyIntervalMilliSeconds": 300,
+  "modifyIntervalMilliSeconds": 1000,
   "guildId": 858188499270369322,
   "exceptionChannelId": 863343940249714709,
   "reminderModifyDays": 5,

--- a/cloudSettings.json
+++ b/cloudSettings.json
@@ -630,7 +630,8 @@
         "3016885"
       ],
       "productNames": [
-        "透羽"
+        "透羽",
+        "Towa"
       ],
       "minPrice": 0,
       "minLike": 10,
@@ -1283,7 +1284,8 @@
         "2198694"
       ],
       "productNames": [
-        "ユキ"
+        "ユキ",
+        "Yuki"
       ],
       "minPrice": 0,
       "minLike": 10,
@@ -1366,7 +1368,8 @@
         "3234473"
       ],
       "productNames": [
-        "アッシュ"
+        "アッシュ",
+        "Ash"
       ],
       "minPrice": 0,
       "minLike": 10,
@@ -1388,7 +1391,9 @@
         "3329958"
       ],
       "productNames": [
-        "くろなつ"
+        "くろなつ",
+        "Kuronatsu",
+        "Kuronatu"
       ],
       "minPrice": 0,
       "minLike": 10,
@@ -1431,7 +1436,10 @@
       "titleKeywords": [],
       "keywords": [
         "髪型",
-        "ヘア"
+        "ヘア",
+        "Hair",
+        "hairstyle",
+        "hairpreset"       
       ],
       "productNames": [],
       "minPrice": 0,

--- a/cloudSettings.json
+++ b/cloudSettings.json
@@ -20,7 +20,7 @@
   "adultWarningImageUrl": "https://raw.githubusercontent.com/aijkl/booth-analytics-assets/main/adult_warning.png",
   "blockRules": [
     {
-      "shopId": "mamamad"
+      "shopId": "mamamad",
       "shopId": "mamamadv3"
     }
   ],

--- a/cloudSettings.json
+++ b/cloudSettings.json
@@ -65,7 +65,7 @@
       "channelId": 863253490369167381
     },
     {
-      "id": "幽狐",
+      "id": "Yuko_1484117",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -90,7 +90,7 @@
       "channelId": 858189387681759232
     },
     {
-      "id": "狐雪",
+      "id": "Koyuki_2554585",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -115,7 +115,7 @@
       "channelId": 863263826442977280
     },
     {
-      "id": "ミーシェ",
+      "id": "Mishe_1256087",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -140,7 +140,7 @@
       "channelId": 863275121909039114
     },
     {
-      "id": "京狐",
+      "id": "Kyoko_1826902",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -165,7 +165,7 @@
       "channelId": 863275176984051762
     },
     {
-      "id": "スノウエルフ",
+      "id": "SnowElf_1202638",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -190,7 +190,7 @@
       "channelId": 863275250569183282
     },
     {
-      "id": "メリノ",
+      "id": "Merino_2351859",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -215,7 +215,7 @@
       "channelId": 863275294131879956
     },
     {
-      "id": "リーメリーバ",
+      "id": "Leeme_Reeva_972559",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -265,7 +265,7 @@
       "channelId": 863275443850575892
     },
     {
-      "id": "薄荷",
+      "id": "Hakka_2215270",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -339,7 +339,7 @@
       "channelId": 863275611584724992
     },
     {
-      "id": "ウルフェリア",
+      "id": "Wolferia_2709610",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -364,7 +364,7 @@
       "channelId": 863275658997399572
     },
     {
-      "id": "みみの",
+      "id": "Mimino_1336133",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -389,7 +389,7 @@
       "channelId": 863275690019127337
     },
     {
-      "id": "ここあ",
+      "id": "Kokoa_2780069",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -414,7 +414,7 @@
       "channelId": 863275737997508668
     },
     {
-      "id": "ラスク",
+      "id": "Rusk_2559783",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -439,7 +439,7 @@
       "channelId": 863275780103864330
     },
     {
-      "id": "ファジー",
+      "id": "Fasy_1255283",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -463,7 +463,7 @@
       "channelId": 863275816582643742
     },
     {
-      "id": "ルシナ",
+      "id": "Rusina_2721156",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -488,7 +488,7 @@
       "channelId": 863275880533196850
     },
     {
-      "id": "キッシュ",
+      "id": "Kisshu_954376",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -514,7 +514,7 @@
       "channelId": 863275920337272852
     },
     {
-      "id": "リアアリス",
+      "id": "Rear_Alice_2146588",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -539,7 +539,7 @@
       "channelId": 863276042759045141
     },
     {
-      "id": "ショコラメイド",
+      "id": "Shokora_Maid_2158487",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -564,7 +564,7 @@
       "channelId": 863276078419804230
     },
     {
-      "id": "イヨ",
+      "id": "Iyo_2630437",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -588,7 +588,7 @@
       "channelId": 863276122425655306
     },
     {
-      "id": "しいか",
+      "id": "Shika_3107492",
       "sql": "",
       "useAvatarRelevanceEvaluation": false,
       "useBlockList": true,
@@ -611,7 +611,7 @@
       "channelId": 863693482013884417
     },
     {
-      "id": "透羽",
+      "id": "Towa_3016885",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -657,7 +657,7 @@
       "channelId": 863685622854189056
     },
     {
-      "id": "ツール",
+      "id": "Tools_etc",
       "sql": "",
       "useAvatarRelevanceEvaluation": false,
       "useBlockList": true,
@@ -706,7 +706,7 @@
       "channelId": 863700080450863104
     },
     {
-      "id": "ティコ",
+      "id": "Tycho_3123433",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -731,7 +731,7 @@
       "channelId": 867674654248665128
     },
     {
-      "id": "ルエナ",
+      "id": "Luena_2910697",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -756,7 +756,7 @@
       "channelId": 868276308747124757
     },
     {
-      "id": "新着アバター(良いね数)",
+      "id": "New_Avatar_Likes_Count",
       "sql": "",
       "useAvatarRelevanceEvaluation": false,
       "useBlockList": true,
@@ -772,7 +772,7 @@
       "channelId": 869793035217666109
     },
     {
-      "id": "新着アバター(値段)",
+      "id": "New_Avatar_Price_Trap",
       "sql": "",
       "useAvatarRelevanceEvaluation": false,
       "useBlockList": true,
@@ -813,7 +813,7 @@
       "channelId": 870107776372834334
     },
     {
-      "id": "レイニィ",
+      "id": "Rainy_2495796",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -857,7 +857,7 @@
       "channelId": 876095790882373632
     },
     {
-      "id": "宙猫",
+      "id": "Soraneco_3046011",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -882,7 +882,7 @@
       "channelId": 877875782305845289
     },
     {
-      "id": "杏里",
+      "id": "Anri_3203894",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -907,7 +907,7 @@
       "channelId": 880986146824400897
     },
     {
-      "id": "メープル",
+      "id": "Maple_1948102",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -931,7 +931,7 @@
       "channelId": 879702480961831012
     },
     {
-      "id": "シアノス",
+      "id": "Syaris_3224415",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -956,7 +956,7 @@
       "channelId": 882120767414870067
     },
     {
-      "id": "新着順",
+      "id": "New_Asset_Orders",
       "sql": "SELECT * FROM products",
       "useAvatarRelevanceEvaluation": false,
       "useBlockList": true,
@@ -970,7 +970,7 @@
       "channelId": 885810966460235777
     },
     {
-      "id": "アダルト",
+      "id": "Adults_Order_List",
       "sql": "SELECT * FROM products WHERE products.is_adult == true",
       "useAvatarRelevanceEvaluation": false,
       "useBlockList": true,
@@ -1032,7 +1032,7 @@
       "channelId": 889779032508477491
     },
     {
-      "id": "イメリス",
+      "id": "Imeris_3040745",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -1055,7 +1055,7 @@
       "channelId": 890423987564331049
     },
     {
-      "id": "のらきゃっと",
+      "id": "Masscat_1216498",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -1081,7 +1081,7 @@
       "channelId": 891140533731360768
     },
     {
-      "id": "セフィラ",
+      "id": "Sephira_2953001",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -1104,7 +1104,7 @@
       "channelId": 891140725335523328
     },
     {
-      "id": "フィリナ",
+      "id": "Firina_1577042",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -1128,7 +1128,7 @@
       "channelId": 891141118840938536
     },
     {
-      "id": "狐薄",
+      "id": "Kohaku_2616595",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -1152,7 +1152,7 @@
       "channelId": 891141410504470598
     },
     {
-      "id": "猫山苗",
+      "id": "Nekoyama_2381911",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -1176,7 +1176,7 @@
       "channelId": 891141951146045470
     },
     {
-      "id": "リンツ",
+      "id": "Linz_1255264",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -1199,7 +1199,7 @@
       "channelId": 891142203752198174
     },
     {
-      "id": "ユウ",
+      "id": "Yuu_2417889",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -1266,7 +1266,7 @@
       "channelId": 891144299473928194
     },
     {
-      "id": "ユキ",
+      "id": "Yuki_2198694",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -1288,7 +1288,7 @@
       "channelId": 892765190951665715
     },
     {
-      "id": "ニャスカ",
+      "id": "Nyasuka_3168874",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -1311,7 +1311,7 @@
       "channelId": 892765453326364734
     },
     {
-      "id": "Quest対応アバター",
+      "id": "Quest_Avatars",
       "sql": "",
       "useAvatarRelevanceEvaluation": false,
       "useBlockList": true,
@@ -1329,7 +1329,7 @@
       "channelId": 894384877393285121
     },
     {
-      "id": "Quest衣装小道具",
+      "id": "Quest_Cloth_Props",
       "sql": "",
       "useAvatarRelevanceEvaluation": false,
       "useBlockList": true,
@@ -1349,7 +1349,7 @@
       "channelId": 894410125861863434
     },
     {
-      "id": "アッシュ",
+      "id": "Ash_3234473",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -1371,7 +1371,7 @@
       "channelId": 899170138107039764
     },
     {
-      "id": "くろなつ",
+      "id": "Kuronatsu_3329958",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -1393,7 +1393,7 @@
       "channelId": 899170267002187846
     },
     {
-      "id": "舞夜",
+      "id": "Maya_3390957",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -1416,7 +1416,7 @@
       "channelId": 904307072324222976
     },
     {
-      "id": "髪型",
+      "id": "Hair_Styles",
       "sql": "",
       "useAvatarRelevanceEvaluation": false,
       "useBlockList": true,
@@ -1437,7 +1437,7 @@
       "channelId": 906344399833813062
     },
     {
-      "id": "アクセサリー",
+      "id": "Accessory_matters",
       "sql": "",
       "useAvatarRelevanceEvaluation": false,
       "useBlockList": true,
@@ -1458,7 +1458,7 @@
       "channelId": 906345001158574140
     },
     {
-      "id": "まりえる",
+      "id": "Marial_3390339",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -1481,7 +1481,7 @@
       "channelId": 906346330736193559
     },
     {
-      "id": "竜胆",
+      "id": "Rindo_3443188",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -1504,7 +1504,7 @@
       "channelId": 911698396421709834
     },
     {
-      "id": "新着アバター(良いね数2)",
+      "id": "New_Avatars_Likes_2",
       "sql": "",
       "useAvatarRelevanceEvaluation": false,
       "useBlockList": true,
@@ -1520,7 +1520,7 @@
       "channelId": 906346810413568051
     },
     {
-      "id": "リフレイン",
+      "id": "Refrain_3450381",
       "sql": "",
       "useAvatarRelevanceEvaluation": true,
       "useBlockList": true,
@@ -1565,7 +1565,7 @@
       "channelId": 913154353249026068
     },
     {
-      "id": "Limited Sale",
+      "id": "Limited_Sale",
       "sql": "SELECT * FROM products WHERE products.is_limited_time AND (products.category = '3Dキャラクター' OR products.category = '3Dモデル（その他）')",
       "useAvatarRelevanceEvaluation": false,
       "useBlockList": true,

--- a/cloudSettings.json
+++ b/cloudSettings.json
@@ -20,7 +20,9 @@
   "adultWarningImageUrl": "https://raw.githubusercontent.com/aijkl/booth-analytics-assets/main/adult_warning.png",
   "blockRules": [
     {
-      "shopId": "mamamad",
+      "shopId": "mamamad"      
+    },
+    {
       "shopId": "mamamadv3"
     }
   ],


### PR DESCRIPTION
*Try to see if increase webhook interval fix some issue.
(discordのwebhookレートリミットを見極めるために投稿間隔を調整)

*Try to remove Japanese name from ID field as sometimes it cause issue as experience.
(IDから日本語を排除、たまにバグる経験があるので。)

*Add English Name to some avatars which I think catch up correctly if something there.
(一部アバターにおいて、英語名を追加指定しました。)

*Add more traps to Hair categories which more likely get some hair matters.
(髪系が結構英語版だと豊富なので追加しました。)

*Some Avatar/Tools/New related categories also renamed into English format if this cause issue with general trap, please commit to fix it.
(一部、一般カテゴリーのID名も英語へ変更したので、一様、一通り何かないかは見ましたが、もしこれで他のリストに影響が出るようであれば再訂正をお願いできれば幸いです。)


Validated by
(利用json確認サイト)
https://jsonformatter.curiousconcept.com/

どこが悪いのか教えてくれるサイトを探してみました。