### PR TITLE
Bump Action/Checkout to v4 + Replace Deprecated JSON Validator

### DIFF
--- a/.github/workflows/validate-json.yml
+++ b/.github/workflows/validate-json.yml
@@ -4,7 +4,7 @@ jobs:
     run:
       runs-on: ubuntu-20.04
       steps:
-         - uses: actions/checkout@v2
+         - uses: actions/checkout@v4
          - name: Detect mixed line endings
            run: |
               MIXED_FILES=$(git ls-files --eol -- . | grep -E 'w/mixed' | cut -c3-)

--- a/.github/workflows/validate-json.yml
+++ b/.github/workflows/validate-json.yml
@@ -1,22 +1,22 @@
 name: Validate json
-on: [push,workflow_dispatch]
+on: [push, workflow_dispatch]
 jobs:
-    run:
-      runs-on: ubuntu-20.04
-      steps:
-         - uses: actions/checkout@v4
-         - name: Detect mixed line endings
-           run: |
-              MIXED_FILES=$(git ls-files --eol -- . | grep -E 'w/mixed' | cut -c3-)
-              if [ -n "$MIXED_FILES" ]; then
-                echo "Found files with mixed line endings:"
-                echo "$MIXED_FILES"
-                exit 1
-              else
-                echo "Line endings are not mixed"
-              fi
-         - name: Validate JSON
-           uses: docker://orrosenblatt/validate-json-action:latest
-           env:
-            INPUT_SCHEMA: schema.json
-            INPUT_JSONS: cloudSettings.json
+  run:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Detect mixed line endings
+        run: |
+          MIXED_FILES=$(git ls-files --eol -- . | grep -E 'w/mixed' | cut -c3-)
+          if [ -n "$MIXED_FILES" ]; then
+            echo "Found files with mixed line endings:"
+            echo "$MIXED_FILES"
+            exit 1
+          else
+            echo "Line endings are not mixed"
+          fi
+      - name: Validate JSON with Glob and Formats
+        uses: ScratchAddons/validate-json-action@master
+        with:
+          schema: ./schema.json
+          jsons: ./cloudSettings.json      


### PR DESCRIPTION
*Action/Checkout version bumped to v4 due to deprecated Node.js.

*Previous JSON Validator use deprecated set-output method so replaced with provider who don't use it.